### PR TITLE
Extended import/export to support files not in the path

### DIFF
--- a/src/fudge.lua
+++ b/src/fudge.lua
@@ -23,7 +23,7 @@ monkey_draw = function(im, ...)
 	elseif type(im)=="table" and im.img and im.quad then
 		old_draw(im.img, im.quad, ...)
 	elseif type(im)=="table" and im.batch then
-		old_draw(im.batch)
+		old_draw(im.batch, ...)
 	elseif type(im)=="table" and im.framerate then
 		anim_draw(im, math.floor(love.timer.getTime()*im.framerate), ...)
 	else


### PR DESCRIPTION
Before fudge exports looked like this:

'''
local f = {width=512,height=512,image=love.graphics.newImage("userinterface.png")}
'''

Now they looks like this:

'''
return function(path)
local file = (path or "").. "userinterface.png"
local f = {width=512,height=512,image=love.graphics.newImage(file)}
'''

This fixes #6 

The API is not changed (export and import are still called the same way) but old atlas descriptors will no longer work.